### PR TITLE
Hotfix/sentence ids

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -11,6 +11,7 @@ dirs:
   processed: processed
   final: final
   models: models
+  hidden: hidden
 
 seed: 4242
 

--- a/src/coral_models/prepare_raw_data.py
+++ b/src/coral_models/prepare_raw_data.py
@@ -294,7 +294,8 @@ def prepare_raw_data(
     input_path: Path | str = Path("data/raw"),
     output_path: Path | str = Path("data/processed"),
     metadata_path: Path | str = Path("data/raw/metadata.csv"),
-):
+    hidden_output_path: Path | str = Path("data/hidden"),
+) -> None:
     """Prepare the raw data.
 
     Args:
@@ -304,10 +305,13 @@ def prepare_raw_data(
             Path to the processed data. Defaults to "data/processed".
         metadata_path (Path or str, optional):
             Path to the metadata. Defaults to "data/raw/metadata.csv".
+        hidden_input_path (Path or str, optional):
+            Path to save sensitive information. Defaults to "data/hidden".
     """
     input_path = Path(input_path)
     output_path = Path(output_path)
     metadata_path = Path(metadata_path)
+    hidden_output_path = Path(hidden_output_path)
 
     # Make speaker-metadata dataframe
     speakers = make_speaker_metadata(input_path, metadata_path)
@@ -402,7 +406,7 @@ def prepare_raw_data(
         f.write(readme)
 
     # Save the dataframes
-    speakers.to_excel(output_path / "speakers.xlsx")
+    speakers.to_excel(hidden_output_path / "speakers.xlsx")
     sentences.to_excel(output_path / "sentences.xlsx")
     recordings.to_excel(output_path / "recordings.xlsx")
 

--- a/src/scripts/build_coral_data.py
+++ b/src/scripts/build_coral_data.py
@@ -1,7 +1,11 @@
 """Script that preprocesses the raw CoRal data.
 
 Usage:
-    python build_coral_data.py <input_path> <metadata_path> <output_path>
+    python src/scripts/build_coral_data.py \
+        <input_path> \
+        <metadata_path> \
+        <output_path> \
+        <hidden_output_path>
 """
 
 import click
@@ -22,8 +26,19 @@ from coral_models.prepare_raw_data import prepare_raw_data
     "output_path",
     type=click.Path(),
 )
-def main(input_path: str, output_path: str, metadata_path: str) -> None:
-    prepare_raw_data(input_path, output_path, metadata_path)
+@click.argument(
+    "hidden_output_path",
+    type=click.Path(),
+)
+def main(
+    input_path: str, output_path: str, metadata_path: str, hidden_output_path: str
+) -> None:
+    prepare_raw_data(
+        input_path=input_path,
+        output_path=output_path,
+        metadata_path=metadata_path,
+        hidden_output_path=hidden_output_path,
+    )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR fixes the way that sentences are assigned ids, i.e. how the `sentence_id` column of `sentences.xlsx` and `recordings.xlsx` are created. Previous it was implicitly assumed that the sentences were unique, which is not the case.

Slight change in the order of operations.