### PR TITLE
Feat/optimise building of asr dataset

### DIFF
--- a/src/scripts/build_coral_asr.py
+++ b/src/scripts/build_coral_asr.py
@@ -4,7 +4,7 @@ Usage:
     python src/scripts/build_coral_asr.py \
         [--audio-dir <audio_dir>] \
         [--metadata-database-path <metadata_database_path>] \
-        [--hub-id <hub_id>] \
+        [--hub-id <hub_id>]
 """
 
 import logging

--- a/src/scripts/build_coral_asr.py
+++ b/src/scripts/build_coral_asr.py
@@ -208,7 +208,7 @@ def build_read_aloud_dataset(metadata_database_path: Path, audio_dir: Path) -> D
             "audio": [row[-1] for row in rows],
         }
     )
-    dataset = dataset.cast_column("audio", Audio(sampling_rate=16_000))
+    dataset = dataset.cast_column("audio", Audio())
     return dataset
 
 

--- a/src/scripts/build_coral_asr.py
+++ b/src/scripts/build_coral_asr.py
@@ -11,6 +11,7 @@ import logging
 import shutil
 import sqlite3
 from pathlib import Path
+from time import sleep
 
 import click
 from datasets import (
@@ -298,17 +299,29 @@ def upload_dataset(
         )
 
 
-def list_audio_files(audio_dir: Path) -> list[Path]:
+def list_audio_files(audio_dir: Path, max_attempts: int = 10) -> list[Path]:
     """List all the audio files in the given directory.
 
     Args:
         audio_dir:
             The directory containing the audio files.
+        max_attempts (optional):
+            The maximum number of attempts to list the audio files. Defaults to 10.
 
     Returns:
         A list of paths to the audio files.
+
+    Raises:
+        OSError:
+            If the audio files cannot be listed.
     """
-    return list(audio_dir.glob("*.wav"))
+    for _ in range(max_attempts):
+        try:
+            return list(audio_dir.glob("*.wav"))
+        except OSError:
+            sleep(1)
+    else:
+        raise OSError(f"Failed to list the audio files in {audio_dir!r}.")
 
 
 def examples_belong_to_train(examples: dict[str, list]) -> list[bool]:

--- a/src/scripts/build_coral_asr.py
+++ b/src/scripts/build_coral_asr.py
@@ -188,7 +188,7 @@ def build_read_aloud_dataset(
     # Get a list of all the audio file paths. We need this since the audio files lie in
     # subdirectories of the main audio directory
     audio_subdirs = list(audio_dir.iterdir())
-    with Parallel(n_jobs=-1) as parallel:
+    with Parallel(n_jobs=-1, backend="threading") as parallel:
         all_audio_path_lists = parallel(
             delayed(list_audio_files)(subdir)
             for subdir in tqdm(audio_subdirs, desc="Collecting audio file paths")
@@ -199,9 +199,9 @@ def build_read_aloud_dataset(
 
     # Match the audio files to the metadata, to ensure that there is a 1-to-1
     # correspondence between them
-    with Parallel(n_jobs=-1) as parallel:
+    with Parallel(n_jobs=-1, backend="threading") as parallel:
         matched_audio_paths = parallel(
-            delayed(get_audio_path)(row, all_audio_paths)
+            delayed(get_audio_path)(row=row, all_audio_paths=all_audio_paths)
             for row in tqdm(rows, desc="Matching audio files to metadata")
         )
     rows = [

--- a/src/scripts/build_coral_asr.py
+++ b/src/scripts/build_coral_asr.py
@@ -13,7 +13,7 @@ import sqlite3
 from pathlib import Path
 
 import click
-from datasets import Audio, Dataset, DatasetDict, disable_progress_bars
+from datasets import Audio, Dataset, DatasetDict
 from joblib import Parallel, delayed
 from tqdm.auto import tqdm
 
@@ -67,8 +67,6 @@ def main(
     batch_size: int,
 ) -> None:
     """Build and upload the CoRal speech recognition dataset."""
-    disable_progress_bars()
-
     metadata_database_path = Path(metadata_database_path)
     audio_dir = Path(audio_dir)
 

--- a/src/scripts/build_coral_asr.py
+++ b/src/scripts/build_coral_asr.py
@@ -229,6 +229,7 @@ def build_read_aloud_dataset(
     return dataset
 
 
+# TODO: Implement this function
 def build_conversation_dataset(
     metadata_database_path: Path, audio_dir: Path, batch_size: int
 ) -> Dataset:
@@ -245,7 +246,6 @@ def build_conversation_dataset(
     Returns:
         The CoRal read-aloud dataset.
     """
-    # TODO: Implement this function
     dataset = Dataset.from_dict({})
     return dataset
 

--- a/src/scripts/build_coral_asr.py
+++ b/src/scripts/build_coral_asr.py
@@ -77,6 +77,11 @@ def main(
         batch_size=batch_size,
     )
 
+    logger.info(
+        "Splitting the CoRal read-aloud dataset into train, validation and test sets..."
+    )
+    read_aloud_dataset = split_dataset(dataset=read_aloud_dataset)
+
     logger.info("Building the CoRal conversation speech recognition dataset...")
     conversation_dataset = build_conversation_dataset(
         metadata_database_path=metadata_database_path,
@@ -84,8 +89,10 @@ def main(
         batch_size=batch_size,
     )
 
-    logger.info("Splitting the dataset into train, validation and test sets...")
-    read_aloud_dataset = split_dataset(dataset=read_aloud_dataset)
+    logger.info(
+        "Splitting the CoRal conversation dataset into train, validation and test "
+        "sets..."
+    )
     conversation_dataset = split_dataset(dataset=conversation_dataset)
 
     logger.info(f"Uploading the dataset to {hub_id!r} on the Hugging Face Hub...")

--- a/src/scripts/build_coral_asr.py
+++ b/src/scripts/build_coral_asr.py
@@ -264,12 +264,13 @@ def split_dataset(dataset: Dataset) -> DatasetDict | None:
         ValueError:
             If no training samples are found.
     """
+    if len(dataset) == 0:
+        return None
+
     train_dataset = dataset.filter(
         function=lambda example: example["id_speaker"] not in VALIDATION_SET_SPEAKER_IDS
         and example["id_speaker"] not in TEST_SET_SPEAKER_IDS
     )
-    if len(train_dataset) == 0:
-        return None
     splits = dict(train=train_dataset)
 
     validation_dataset = dataset.filter(


### PR DESCRIPTION
This optimises the building of the dataset, from previous ~5 hours to ~1 minute.

It still takes a fair amount of time to upload the dataset to the hub though, around 4-8 hours (haven't finished a full upload yet, so basing this off tqdm estimates).

The following optimisations were made:

1. Copy the database from NAS to disk, which reduces reading data from the database from ~1.5 hours to ~10 seconds. We also don't need batching anymore, which yields a slight speedup.
2. When matching metadata with audio files, we store a `filename -> path` mapping initially, and use the `dict.get` method instead of the previous list comprehension. This reduces the matching from ~1.5-2 hours to ~1 second.
3. Split the dataset in batches, which reduces the time from ~1-2 hours to <1 second.

Tried to optimise the collection of all the audio paths, which currently takes ~1 minute, but none of my attempts worked. This is responsible for ~99% of the time spent actually building the dataset.

Of course the ultimate bottleneck is the uploading of the data, but I'm not sure how that can be improved. It _does_ include some I/O as it has to package all the audio files into the parquet format, but the only way to improve this might be copying all the audio files to disk first, but that puts quite a large requirement on disk space (takes up ~83 GB).

This PR also fixes the sample rate issue, where I previously enforced 16k sampling rate, but now uses the native one, being 48k.